### PR TITLE
Cleaned up file paths to match newrelic and added ubuntu init.d script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation Instructions
 
 * See pip installation instructions at http://www.pip-installer.org/en/latest/installing.html
 
-2. Copy the configuration file example from /opt/newrelic_plugin_agent/etc/example.yml to /etc/newrelic_plugin_agent.yml and edit the configuration in that file.
+2. Copy the configuration file example from /opt/newrelic_plugin_agent/etc/newrelic/newrelic_plugin_agent.cfg to /etc/newrelic/newrelic_plugin_agent.cfg and edit the configuration in that file.
 
 3. Run the app:
 
@@ -97,7 +97,7 @@ Configuration Example
     %YAML 1.2
     ---
     Application:
-      license_key: VALUE
+      license_key: REPLACE_WITH_REAL_KEY
       poll_interval: 60
 
       apache_httpd:
@@ -167,7 +167,7 @@ Configuration Example
         port: 8098
 
     Daemon:
-      pidfile: /var/run/newrelic_plugin_agent.pid
+      pidfile: /var/run/newrelic/newrelic_plugin_agent.pid
 
     Logging:
       formatters:
@@ -177,7 +177,7 @@ Configuration Example
         file:
           class : logging.handlers.RotatingFileHandler
           formatter: verbose
-          filename: /tmp/newrelic_plugin_agent.log
+          filename: /var/log/newrelic/newrelic_plugin_agent.log
           maxBytes: 10485760
           backupCount: 3
       loggers:

--- a/etc/init.d/newrelic_plugin_agent.deb
+++ b/etc/init.d/newrelic_plugin_agent.deb
@@ -1,0 +1,314 @@
+#! /bin/sh
+#
+### BEGIN INIT INFO
+# Provides:          newrelic_plugin_agent
+# Required-Start:    $network $local_fs $remote_fs
+# Required-Stop:     $remote_fs
+# Should-Start:      $named
+# Should-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: The New Relic Plugin Agent
+# Description:       The New Relic Plugin Agent
+### END INIT INFO
+
+LANG=
+PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/usr/local/bin
+LABEL=newrelic_plugin_agent
+NAME=newrelic_plugin_agent
+PROG=newrelic_plugin_agent
+DESC="New Relic Plugin Agent"
+
+id=`id -u 2> /dev/null`
+if [ "$id" != "0" ]; then
+  if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+    echo "ERROR: must run $0 as root"
+  fi
+  exit 4
+fi
+
+if [ -f /lib/lsb/init-function ]; then
+  . /lib/lsb/init-functions
+else
+log_begin_msg() {
+  echo -n "$@"
+}
+
+log_end_msg() {
+  if [ $1 -eq 0 ]; then
+    echo " OK"
+  else
+    echo " FAILED"
+  fi
+}
+
+fi
+
+# Source the defaults
+if [ -f /etc/default/${NAME} ]; then
+  . /etc/default/${NAME}
+fi
+
+if [ -z "${nrdaemon}" ]; then
+  if [ -x /usr/bin/${PROG} ]; then
+    nrdaemon=/usr/bin/${PROG}
+  elif [ -x /usr/local/bin/${PROG} ]; then
+    nrdaemon=/usr/local/bin/${PROG}
+  fi
+fi
+
+if [ -z "${nrdaemon}" ]; then
+  if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+    echo "ERROR: ${PROG} not found"
+  fi
+  exit 6
+fi
+
+if [ ! -x "${nrdaemon}" ]; then
+  if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+    echo "ERROR: ${nrdaemon} not executable"
+  fi
+  exit 6
+fi
+
+if [ -z "${cfgfile}" ]; then
+  if [ -f /etc/newrelic/${PROG}.cfg ]; then
+    cfgfile=/etc/newrelic/${PROG}.cfg
+  elif [ -f /etc/${PROG}.cfg ]; then
+    cfgfile=/etc/${PROG}.cfg
+  elif [ -f /usr/local/etc/${PROG}.cfg ]; then
+    cfgfile=/usr/local/etc/${PROG}.cfg
+  fi
+
+  if [ -z "${cfgfile}" ]; then
+    cfgfile=`echo "${nrdaemon}" | sed -e "s/${PROG}/${PROG}.cfg/" 2> /dev/null`
+  fi
+fi
+
+if [ ! -f "${cfgfile}" ]; then
+  if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+    echo "ERROR: ${PROG}.cfg not found"
+  fi
+  exit 5
+fi
+
+pidfile=`sed -n -e 's/^[ 	]*pidfile[ 	]*=[ 	]*//p' -e 's/[ 	]*$//' "${cfgfile}" 2> /dev/null`
+
+pidarg=
+if [ -z "${pidfile}" ]; then
+  if [ -d /var/run/newrelic ]; then
+    pidfile=/var/run/newrelic/${PROG}.pid
+  elif [ -d /var/pid ]; then
+    pidfile=/var/pid/${PROG}.pid
+  elif [ -d /var/run ]; then
+    pidfile=/var/run/${PROG}.pid
+  else
+    pidfile=/etc/${PROG}.pid
+  fi
+  pidarg=" -p ${pidfile}"
+fi
+
+nrdaemonopts="-c ${cfgfile}${pidarg}"
+
+#
+# Time to wait for the daemon to die, in seconds. If you set this too low the
+# daemon may not have enough time to flush pending data with the New Relic
+# servers, and the restart command may not work.
+#
+DODTIME=15
+
+# Check if a given process pid's cmdline matches a given name
+running_pid()
+{
+  pid=$1
+  name=$2
+  [ -z "$pid" ] && return 1
+  [ ! -d /proc/$pid ] && return 1
+  cmd=`cat /proc/$pid/cmdline | tr "\000" "\n"|head -n 1 |cut -d : -f 1`
+  # Is this the expected child?
+  [ "$cmd" = "$name" ] || return 1
+  return 0
+}
+
+# Check if the process is running looking at /proc
+running()
+{
+  # No pidfile, probably no daemon present
+  [ -f "${pidfile}" ] || return 1
+  # Obtain the pid and check it against the binary name
+  pid=`cat ${pidfile}`
+  running_pid "${pid}" "${nrdaemon}" || return 1
+  return 0
+}
+
+# Forcefully kill the process. Attempt to do a clean shutdown using the daemon
+# command but fall back to using signals if we must.
+force_stop() {
+  if running ; then
+    kill -15 ${pid} > /dev/null 2>&1
+    tleft=0
+    while test $tleft -lt $DODTIME; do
+      if running ; then
+        sleep 1
+        tleft=$(($tleft+1))
+      else
+        return 0
+      fi
+    done
+  else
+    return 0
+  fi
+
+  if running ; then
+    kill -9 ${pid} > /dev/null 2>&1
+    tleft=0
+    while test $tleft -lt 5; do
+      if running; then
+        sleep 1
+        tleft=$(($tleft+1))
+      else
+        return 0
+      fi
+    done
+  fi
+
+  if running ; then
+    return 1
+  fi
+
+  return 0
+}
+
+start() {
+  if running ; then
+    if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+      echo "$DESC: $NAME already running"
+    fi
+    exit 0
+  fi
+
+
+  HAVE_LICENSE_KEY="yes"
+  if sed -e '/^[ 	]*#/d' "${cfgfile}" 2> /dev/null | grep -q 'REPLACE_WITH_REAL_KEY' 2> /dev/null; then
+    if [ ! -z "$NEW_RELIC_LICENSE_KEY" ]; then
+      sed -i.bak -e "s/^\(\s*\)\(license_key:\).*/\\1\\2 ${NEW_RELIC_LICENSE_KEY}/" "${cfgfile}" 2>/dev/null
+      if [ ! $? ]; then
+        HAVE_LICENSE_KEY="no"
+      fi
+    else
+      HAVE_LICENSE_KEY="no"
+    fi
+  fi
+
+  if [ "x$HAVE_LICENSE_KEY" = "xno" ]; then
+    if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+      cat <<EOF
+
+*********************************************************************
+*********************************************************************
+***
+***  Can not start the New Relic Plugin Agent until you insert a
+***  valid license key in the following file:
+***
+***     ${cfgfile}
+***
+***  No data will be reported until the plugin agent can start.
+***  You can get your New Relic key from the 'Configuration' section
+***  of the 'Support' menu of your New Relic account (accessible at
+***  https://rpm.newrelic.com).
+***
+*********************************************************************
+*********************************************************************
+
+EOF
+    fi
+    exit 1
+  fi
+
+  if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+    log_begin_msg "Starting $DESC: $NAME"
+  fi
+
+  RETVAL=0
+  if [ -z "${RUNAS}" -o "${RUNAS}" = "root" ]; then
+    "${nrdaemon}" ${nrdaemonopts} || RETVAL=1
+  else
+    cfgpath=`dirname ${cfgfile}`
+    chmod og+x ${cfgpath}
+    touch "${pidfile}" && chown "${RUNAS}" "${pidfile}"
+    su ${RUNAS} -s /bin/sh -c "env -i ${nrdaemon} ${nrdaemonopts}" || RETVAL=1
+  fi
+
+  sleep 1
+  if [ "x${RETVAL}" = "x0" ]; then
+    if running ; then
+      RETVAL=0
+    else
+      RETVAL=1
+    fi
+  fi
+
+  if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+    log_end_msg $RETVAL
+  fi
+  return $RETVAL
+}
+
+stop() {
+  if running; then
+    if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+      log_begin_msg "Stopping $DESC: $NAME"
+    fi
+    force_stop
+    RETVAL=$?
+    if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+      log_end_msg $RETVAL
+    fi
+    return $RETVAL
+  fi
+  return 0
+}
+
+status() {
+  if running ; then
+    isnot="is"
+    RETVAL=0
+  else
+    isnot="is not"
+    if [ -f "$pidfile" ]; then
+      RETVAL=1
+    else
+      RETVAL=3
+    fi
+  fi
+
+  if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+    echo "$DESC: $NAME ${isnot} running"
+  fi
+  exit $RETVAL
+}
+
+case "$1" in
+  start)
+    start || exit 1
+    ;;
+  stop | force-stop)
+    stop || exit 1
+    ;;
+  force-reload | restart)
+    stop || exit 1
+    sleep 1
+    start || exit 1
+    ;;
+  status)
+    status
+    ;;
+  *)
+    if [ -z "${NR_SILENT}" -a -z "${SILENT}" ]; then
+      echo "Usage: $0 {start|stop|restart|force-reload|status|force-stop}" >&2
+    fi
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/etc/init.d/newrelic_plugin_agent.rhel
+++ b/etc/init.d/newrelic_plugin_agent.rhel
@@ -12,10 +12,10 @@
 APP="/usr/bin/newrelic_plugin_agent"
 
 # Configuration dir
-CONFIG_DIR="/etc"
+CONFIG_DIR="/etc/newrelic"
 
 # PID File
-PID_FILE="/var/run/newrelic_plugin_agent.pid"
+PID_FILE="/var/run/newrelic/newrelic_plugin_agent.pid"
 
 # Additional arguments
 OPTS=""
@@ -26,7 +26,7 @@ if [ -f /etc/sysconfig/newrelic_plugin_agent ]; then
 fi
 
 # Configuration file
-CONF="${CONF:-${CONFIG_DIR}/newrelic_plugin_agent.yml}"
+CONF="${CONF:-${CONFIG_DIR}/newrelic_plugin_agent.cfg}"
 
 if [ ! -f "${CONF}" ]; then
   echo -n $"cannot find newrelic_plugin_agent configuration file: '${CONF}'"

--- a/etc/newrelic/newrelic_plugin_agent.cfg
+++ b/etc/newrelic/newrelic_plugin_agent.cfg
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 Application:
-  license_key: VALUE
+  license_key: REPLACE_WITH_REAL_KEY
   poll_interval: 60
 
   #apache_httpd:
@@ -70,7 +70,7 @@ Application:
 
 
 Daemon:
-  pidfile: /var/run/newrelic_plugin_agent.pid
+  pidfile: /var/run/newrelic/newrelic_plugin_agent.pid
 
 Logging:
   formatters:
@@ -80,7 +80,7 @@ Logging:
     file:
       class : logging.handlers.RotatingFileHandler
       formatter: verbose
-      filename: /tmp/newrelic_plugin_agent.log
+      filename: /var/log/newrelic/newrelic_plugin_agent.log
       maxBytes: 10485760
       backupCount: 3
   loggers:

--- a/newrelic_plugin_agent/agent.py
+++ b/newrelic_plugin_agent/agent.py
@@ -1,5 +1,5 @@
 """
-Redis Agent for the New Relic Platform
+Multiple Plugin Agent for the New Relic Platform
 
 """
 import clihelper
@@ -18,8 +18,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class NewRelicPluginAgent(clihelper.Controller):
-    """The NewRelicRedisAgent class implements a agent that polls Redis
-    every minute and reports the state of a Redis cluster to NewRelic.
+    """The NewRelicPluginAgent class implements a agent that polls plugins
+    every minute and reports the state to NewRelic.
 
     """
     IGNORE_KEYS = ['license_key', 'poll_interval']


### PR DESCRIPTION
I modified all file paths to reside in the existing NewRelic directories and match NewRelic formats. For example:
/etc/newrelic_plugin_agent.yml  ==> /etc/newrelic/newrelic_plugin_agent.cfg

I also added an init.d script for Ubuntu/Debian that is based on /etc/init.d/newrelic-sysmond.

Does it make sense to also change from underscores to hyphens to match NewRelic program names?
