### PR TITLE
Drop privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Configuration Example
         port: 8098
 
     Daemon:
+      user: newrelic
       pidfile: /var/run/newrelic/newrelic_plugin_agent.pid
 
     Logging:

--- a/etc/newrelic/newrelic_plugin_agent.cfg
+++ b/etc/newrelic/newrelic_plugin_agent.cfg
@@ -70,6 +70,7 @@ Application:
 
 
 Daemon:
+  user: newrelic
   pidfile: /var/run/newrelic/newrelic_plugin_agent.pid
 
 Logging:


### PR DESCRIPTION
I added a configuration option "user" to the Daemon configuration to drop privileges.
Dropping privileges of a daemon to non-root is essential for security reasons.
