### PR TITLE
Fix for multiple hosts per plugin sharing derived value storage

### DIFF
--- a/newrelic_plugin_agent/agent.py
+++ b/newrelic_plugin_agent/agent.py
@@ -291,9 +291,10 @@ class NewRelicPluginAgent(clihelper.Controller):
     def thread_process(self, name, plugin, config, poll_interval):
         LOGGER.debug('Polling %s, %r, %r, %r',
                      name, plugin, config, poll_interval)
-        obj = plugin(config, poll_interval, self.derive_last_interval.get(name))
+        instance_name = "%s:%s" % (name, config.get('name','unnamed'))
+        obj = plugin(config, poll_interval, self.derive_last_interval.get(instance_name))
         obj.poll()
-        self.publish_queue.put((name, obj.values(), obj.derive_last_interval))
+        self.publish_queue.put((instance_name, obj.values(), obj.derive_last_interval))                                                       
 
     @property
     def wake_interval(self):


### PR DESCRIPTION
Have been using the changes from c73f816 (from #63) to allow multiple hosts per plugin, and I've noticed a bug where each of these instances of the plugin uses the same location to store its derived values, causing abnormal values to be reported (one of our memcached instances was apparently doing about -200000 Get requests a minute).

Here's a quick fix I've put in to our code that seems to fix the problem, by just separating multiple instances of the same plugin by extending their key with the name as defined in the config file.
