### PR TITLE
Rabbitmq plugin: add tracking options for vhosts and queues

### DIFF
--- a/etc/newrelic/newrelic_plugin_agent.cfg
+++ b/etc/newrelic/newrelic_plugin_agent.cfg
@@ -108,6 +108,11 @@ Application:
   #  verify_ssl_cert: true
   #  username: guest
   #  password: guest
+  #  vhosts: # [OPTIONAL, track this vhosts' queues only]
+  #    production_vhost:
+  #      queues: [encode_video, ] # [OPTIONAL, track this queues only]
+  #    staging_vhost: # [track every queue for this vhost]
+  #
 
   #redis:
   #  - name: localhost


### PR DESCRIPTION
Hi,
as we have lots of vhosts and queues but just few are really hi prio for us (and NR queue screen seems to kill every browser when loading graphs for more than 100 metrics) I made possible to whitelist the queues to track in NR.
This should not require any edit for existing users (unless they want this kind of tracking).
