### PR TITLE
Use keyword arguments for psycopg2.connect()

### DIFF
--- a/newrelic_plugin_agent/plugins/postgresql.py
+++ b/newrelic_plugin_agent/plugins/postgresql.py
@@ -230,22 +230,24 @@ class PostgreSQL(base.Plugin):
         :rtype: psycopg2.connection
 
         """
-        conn = psycopg2.connect(self.dsn)
+        conn = psycopg2.connect(**self.connection_arguments)
         conn.set_isolation_level(extensions.ISOLATION_LEVEL_AUTOCOMMIT)
         return conn
 
     @property
-    def dsn(self):
-        """Create a DSN to connect to
+    def connection_arguments(self):
+        """Create connection parameter dictionary for psycopg2.connect
 
-        :return str: The DSN to connect
-
+        :return dict: The dictionary to be passed to psycopg2.connect via double-splat
         """
-        dsn = "host='%(host)s' port=%(port)i dbname='%(dbname)s' " \
-              "user='%(user)s'" % self.config
-        if self.config.get('password'):
-            dsn += " password='%s'" % self.config['password']
-        return dsn
+        filtered_args = ["name","superuser"]
+        args = {}
+        for key in set(self.config) - set(filtered_args):
+            if key == 'dbname':
+                args['database'] = self.config[key]
+            else:
+                args[key] = self.config[key]
+        return args
 
     def poll(self):
         self.initialize()


### PR DESCRIPTION
Advantages:
- Keyword arguments can be constructed pretty much directly from the
  YAML
- validation of parameters is left to libpq
  - host, user, port, and database were unneccessarily mandatory, which
    prevented the use of a unix socket to connect to postgres
- any parameters [libpq supports](http://www.postgresql.org/docs/current/static/libpq-
  connect.html#LIBPQ-PARAMKEYWORDS) can be just added to the YAML.

Disadvantages:
- Currently the config structure is such that the superuser and/or name
  keys need to be filtered from the config dictionary.  This could be
  eliminated by creating a map specifically for the connection info (see
  below for sample.) I avoided doing this so as not to require a
  configuration change for this pull request, but I'd be happy to
  implement it.

``` yaml
postgresql:
  connection:
    host: localhost
    port: 5432
    user: postgres
    database: postgres
  superuser: False
```

Sponsored-by: CentroNet Marketing http://www.centronetmarketing.com
