### PR TITLE
Redis hit ratio

### DIFF
--- a/newrelic_plugin_agent/plugins/redis.py
+++ b/newrelic_plugin_agent/plugins/redis.py
@@ -42,7 +42,7 @@ class Redis(base.SocketStatsPlugin):
             total = hits + misses
 
             if total > 0:
-                self.add_gauge_value('Hit Ratio', '', 100 * hits / total)
+                self.add_gauge_value('Hits Ratio', '', 100 * hits / total)
 
         self.add_derive_value('Keys/Evicted', '',
                               stats.get('evicted_keys', 0))


### PR DESCRIPTION
Hi there,

redis hits ration, i.e. hits / (hits+misses) is a really useful measure that we are currently tracking with scoutapp, and it would be nice to also have it in here!

This is pretty much a direct port from the ruby scout plugin (https://github.com/scoutapp/scout-plugins/pull/116) to python. It wasn't tested at all (not really sure how to ...)

And as far as I can tell, adding a new graph on the dashboard happens in NR directly, right?
