### PR TITLE
Fix incomplete read of uwsgi stats data

### DIFF
--- a/newrelic_plugin_agent/plugins/base.py
+++ b/newrelic_plugin_agent/plugins/base.py
@@ -254,14 +254,21 @@ class SocketStatsPlugin(Plugin):
         else:
             return connection
 
-    def fetch_data(self, connection):
+    def fetch_data(self, connection, read_till_empty=False):
         """Read the data from the socket
 
         :param  socket connection: The connection
 
         """
         LOGGER.debug('Fetching data')
-        return connection.recv(self.SOCKET_RECV_MAX)
+        received = connection.recv(self.SOCKET_RECV_MAX)
+        while read_till_empty:
+            chunk = connection.recv(self.SOCKET_RECV_MAX)
+            if chunk:
+                received += chunk
+            else:
+                break
+        return received
 
     def poll(self):
         """This method is called after every sleep interval. If the intention

--- a/newrelic_plugin_agent/plugins/uwsgi.py
+++ b/newrelic_plugin_agent/plugins/uwsgi.py
@@ -90,7 +90,7 @@ class uWSGI(base.SocketStatsPlugin):
         :return: dict
 
         """
-        data = super(uWSGI, self).fetch_data(connection)
+        data = super(uWSGI, self).fetch_data(connection, read_till_empty=True)
         if data:
             return json.loads(data)
         return {}


### PR DESCRIPTION
... and do that in a way that can be reused by other plugins whose
server side closes the connection when complete. (Not kosher for server
sides that keep the connection open, like memcached; trying to keep
reading would block in that case. So it's off by default, enabled only
by the uwsgi plugin.)

fixes MeetMe/newrelic-plugin-agent#139
