### PR TITLE
Redis: Fixes name of last-save status variable

### DIFF
--- a/newrelic_plugin_agent/plugins/redis.py
+++ b/newrelic_plugin_agent/plugins/redis.py
@@ -58,7 +58,9 @@ class Redis(base.SocketStatsPlugin):
         self.add_derive_value('Connections', '',
                               stats.get('total_connections_received', 0))
         self.add_derive_value('Changes Since Last Save', '',
-                              stats.get('changes_since_last_save', 0))
+                              stats.get('rdb_changes_since_last_save', 0))
+        self.add_derive_value('Last Save Time', '',
+                              stats.get('rdb_last_bgsave_time_sec', 0))
 
         self.add_gauge_value('Pubsub/Commands', '',
                              stats.get('pubsub_commands', 0))


### PR DESCRIPTION
On our NR, the 'changes since last save' shows up as blank. 
According to http://redis.io/commands/INFO the variable 
to check has a slightly different name.

Also adds a useful metric (time taken to save db) which
can indicate problems if it spikes.
