### PR TITLE
Updating edgecast.py to use https per Edgecast

### DIFF
--- a/newrelic_plugin_agent/plugins/edgecast.py
+++ b/newrelic_plugin_agent/plugins/edgecast.py
@@ -81,7 +81,7 @@ class Edgecast(base.Plugin):
 
     @property
     def edgecast_base_url(self):
-        return 'http://api.edgecast.com/v2/{API}/customers/%(account)s' % \
+        return 'https://api.edgecast.com/v2/{API}/customers/%(account)s' % \
                self.config
 
     def fetch_bandwidth_values(self):


### PR DESCRIPTION
Edgecast now requires https and will be deprecating http.

"EdgeCast would like to remind you that all API calls over HTTP after December 31st, 2013 cutover will no longer be accepted."
