### PR TITLE
filter out the relation_stats parameter

### DIFF
--- a/newrelic_plugin_agent/plugins/postgresql.py
+++ b/newrelic_plugin_agent/plugins/postgresql.py
@@ -241,7 +241,7 @@ class PostgreSQL(base.Plugin):
 
         :return dict: The dictionary to be passed to psycopg2.connect via double-splat
         """
-        filtered_args = ["name","superuser"]
+        filtered_args = ["name","superuser","relation_stats"]
         args = {}
         for key in set(self.config) - set(filtered_args):
             if key == 'dbname':


### PR DESCRIPTION
without this, if you use relation_stats in your configuration, this
happens:

```
CRITICAL   2014-01-16 00:20:27,655 19372  MainProcess     MainThread newrelic_plugin_agent.plugins.postgresql      poll                      L259   : Could not connect to PostgreSQL, skipping stats run: invalid connection option "relation_stats"
```

This is a major blocker for us to use the agent, so the sooner this can be released, the happier I'll be :)
