### PR TITLE
catch Timeout exception

### DIFF
--- a/newrelic_plugin_agent/agent.py
+++ b/newrelic_plugin_agent/agent.py
@@ -233,6 +233,8 @@ class NewRelicPluginAgent(helper.Controller):
                          response.content.strip())
         except requests.ConnectionError as error:
             LOGGER.error('Error reporting stats: %s', error)
+        except requests.Timeout as error:
+            LOGGER.error('TimeoutError reporting stats: %s', error)
 
     @staticmethod
     def _get_plugin(plugin_path):


### PR DESCRIPTION
After adding the timeout code we need to catch the Timeout exception.

Note: Think we are still missing the rollup after an error occurs. At this moment the metrics are lost.
