### PR TITLE
fix for ticket #201 do not crash when redis plugin cannot connect to server

### DIFF
--- a/newrelic_plugin_agent/plugins/redis.py
+++ b/newrelic_plugin_agent/plugins/redis.py
@@ -109,7 +109,7 @@ class Redis(base.SocketStatsPlugin):
 
         """
         connection = super(Redis, self).connect()
-        if self.config.get('password'):
+        if connection and self.config.get('password'):
             connection.send("*2\r\n$4\r\nAUTH\r\n$%i\r\n%s\r\n" %
                             (len(self.config['password']),
                              self.config['password']))


### PR DESCRIPTION
Patch to have the plugin check if the Redis connection was established before trying to send AUTH command for credentials.

This should stop the agent from dying when it cannot connect to the Redis server.
