### PR TITLE
Apache and Nginx should only allow localhost by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ Enable the HTTPd server status page in the default virtual host. The following e
         SetHandler server-status
         Order deny,allow
         Deny from all
-        Allow from all
+        Allow from 127.0.0.1
     </Location>
 
 For HTTPd 2.4, it should look something like:
@@ -222,6 +222,8 @@ Enable the Nginx ``stub_status`` setting on the default site in your configurati
 
       location /nginx_stub_status {
         stub_status on;
+        allow 127.0.0.1;
+        deny all;
       }
 
 If you are monitoring Nginx via a HTTPS connection you can use the ``verify_ssl_cert`` configuration value in the httpd configuration section to disable SSL certificate verification.


### PR DESCRIPTION
Just to make sure people don't just copy/paste this stuff.
