### PR TITLE
Adding Elasticsearch HTTP authentication functionality for issue #262

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,10 @@ The agent requires the extended information to parse metrics. If you are not see
 
 If you are monitoring Apache HTTPd via a HTTPS connection you can use the ``verify_ssl_cert`` configuration value in the httpd configuration section to disable SSL certificate verification.
 
+Elasticsearch Installation Notes
+--------------------------------
+The configuration variables "username and "password" apply only to installations using specific plugins, such as https://github.com/sonian/elasticsearch-jetty, to provide HTTP authentication.  This is not default Elasticsearch functionality.
+
 Memcached Installation Notes
 ----------------------------
 The memcached plugin can communicate either over UNIX domain sockets using the path configuration variable or TCP/IP using the host and port variables. Do not include both.
@@ -302,6 +306,8 @@ Configuration Example
         name: clustername
         host: localhost
         port: 9200
+        #username: foo
+        #password: bar
 
       haproxy:
         name: my-haproxy-server

--- a/newrelic_plugin_agent/plugins/elasticsearch.py
+++ b/newrelic_plugin_agent/plugins/elasticsearch.py
@@ -44,7 +44,11 @@ class ElasticSearch(base.JSONStatsPlugin):
     def add_cluster_stats(self):
         """Add stats that go under Component/Cluster"""
         url = self.stats_url.replace(self.DEFAULT_PATH, '/_cluster/health')
-        response = requests.get(url)
+        if self.config.get('username') and self.config.get('password'):
+            response = requests.get(url, auth=(self.config.get('username'), self.config.get('password')))
+        else:
+            response = requests.get(url)
+
         if response.status_code == 200:
             data = response.json()
             self.add_gauge_value('Cluster/Nodes', 'nodes',


### PR DESCRIPTION
Hello,

This relates to https://github.com/MeetMe/newrelic-plugin-agent/issues/262 .  I needed to get this working for my Elasticsearch/NewRelic install, so I've checked that this works like it ought to.  There may be a more elegant way to code this - apologies, I'm not a Python programmer, but I think this (or something like it) ought to be pretty uncontroversial.

Thanks!
