### PR TITLE
Added striping of HTTP_COOKIE header in uWSGI plugin

### DIFF
--- a/newrelic_plugin_agent/plugins/uwsgi.py
+++ b/newrelic_plugin_agent/plugins/uwsgi.py
@@ -4,6 +4,7 @@ uWSGI
 """
 import json
 import logging
+import re
 
 from newrelic_plugin_agent.plugins import base
 
@@ -94,6 +95,7 @@ class uWSGI(base.SocketStatsPlugin):
         """
         data = super(uWSGI, self).fetch_data(connection, read_till_empty=True)
         if data:
+            data = re.sub(r'"HTTP_COOKIE=[^"]*"', '""', data)
             return json.loads(data)
         return {}
 


### PR DESCRIPTION
uWSGI stats server returns environment variables inside "cores" list. That list contains HTTP_COOKIE header. That header can contain octal-escaped characters and that will raise ValueError during json parsing. I think the simplest way is just to strip that header at all since it doesn't used for any data.
