### PR TITLE
fix issue #263 - have elasticsearch collect data from the entire cluster

### DIFF
--- a/newrelic_plugin_agent/plugins/elasticsearch.py
+++ b/newrelic_plugin_agent/plugins/elasticsearch.py
@@ -183,7 +183,7 @@ class ElasticSearch(base.JSONStatsPlugin):
             if isinstance(values[key], dict):
                 if key not in tree:
                     tree[key] = dict()
-                    self.process_tree(tree[key], values[key])
+                self.process_tree(tree[key], values[key])
             elif isinstance(values[key], int):
                 if key not in tree:
                     tree[key] = 0


### PR DESCRIPTION
This fixes the collection for elasticsearch as specified in issue #263.

Previous to this commit, it would only report data from the specific node rather than the entire cluster. This was a problem in our case as we have a node which just acts as a router to 2 data nodes, so we weren't seeing any docs being reported in newrelic.
