### PR TITLE
Fix elasticsearch plugin not using auth for cluster stats request.

### DIFF
--- a/newrelic_plugin_agent/plugins/base.py
+++ b/newrelic_plugin_agent/plugins/base.py
@@ -335,16 +335,19 @@ class HTTPStatsPlugin(Plugin):
         data = self.http_get()
         return data.content if data else ''
 
-    def http_get(self):
-        """Fetch the data from the stats URL
+    def http_get(self, url=None):
+        """Fetch the data from the stats URL or a specified one.
 
+        :param str url: URL to fetch instead of the stats URL
         :rtype: requests.models.Response
 
         """
         LOGGER.debug('Polling %s Stats at %s',
-                     self.__class__.__name__, self.stats_url)
+                     self.__class__.__name__, url or self.stats_url)
+        req_kwargs = self.request_kwargs
+        req_kwargs.update({'url': url} if url else {})
         try:
-            response = requests.get(**self.request_kwargs)
+            response = requests.get(**req_kwargs)
         except requests.ConnectionError as error:
             LOGGER.error('Error polling stats: %s', error)
             return ''

--- a/newrelic_plugin_agent/plugins/elasticsearch.py
+++ b/newrelic_plugin_agent/plugins/elasticsearch.py
@@ -44,7 +44,7 @@ class ElasticSearch(base.JSONStatsPlugin):
     def add_cluster_stats(self):
         """Add stats that go under Component/Cluster"""
         url = self.stats_url.replace(self.DEFAULT_PATH, '/_cluster/health')
-        response = requests.get(url)
+        response = self.http_get(url)
         if response.status_code == 200:
             data = response.json()
             self.add_gauge_value('Cluster/Nodes', 'nodes',


### PR DESCRIPTION
This fixes a problem where the additional request that the elasticsearch plugin does for cluster stats doesn't use the full `request_kwargs` from the config, causing authentication to fail in scenarios where it is required (found.no hosted Elasticsearch in this case).

This also extends `HTTPStatsPlugin.http_get()` with a `url` parameter for use by any other plugin that needs to grab stats from additional URLs.
