### PR TITLE
Make startup script work on Ubuntu

### DIFF
--- a/etc/init.d/newrelic-plugin-agent.deb
+++ b/etc/init.d/newrelic-plugin-agent.deb
@@ -19,7 +19,7 @@ DAEMON_OPTS="-c $CONFIG"
 DESC="New Relic Plugin Agent"
 TIMEOUT=5
 PIDDIR_MODE=755
-PIDDIR_OWNER=
+PIDDIR_OWNER="newrelic"
 PIDDIR_OWNER_FALLBACK="root"
 
 # Include newrelic plugin agent defaults if available


### PR DESCRIPTION
Empty value for PIDDIR_OWNER causes code on line 51 and 55 to fail. This resulted in the following output at startup time (in /var/log/boot.log):
install: invalid user `-g'
- PID directory was not found and created
  Error starting /usr/local/bin/newrelic-plugin-agent: Cannot write to specified p
  id file path /var/run/newrelic/newrelic-plugin-agent.pid
