### PR TITLE
Fix condition to check if queue is temporary.

### DIFF
--- a/newrelic_plugin_agent/plugins/rabbitmq.py
+++ b/newrelic_plugin_agent/plugins/rabbitmq.py
@@ -224,7 +224,7 @@ class RabbitMQ(base.Plugin):
         available, consumers, deliver, publish, redeliver, unacked = \
             0, 0, 0, 0, 0, 0
         for count, queue in enumerate(queue_data):
-            if queue['name'][0:6] == 'amq.gen':
+            if queue['name'][0:7] == 'amq.gen':
                 LOGGER.debug('Skipping auto-named queue: %s', queue['name'])
                 continue
 


### PR DESCRIPTION
The current condition is always false. The slice `queue['name'][0:6]` will get the first 6 characters of the queue name, in the case of a temporary queue it will be `amq.ge`, instead of `amq.gen`.

The plugin is reporting metrics for temporary queues, which is undesirable.
