### PR TITLE
Fix error, when any plugin returns NoneType instead of number value.

### DIFF
--- a/newrelic_plugin_agent/plugins/base.py
+++ b/newrelic_plugin_agent/plugins/base.py
@@ -178,6 +178,9 @@ class Plugin(object):
         :rtype: dict
 
         """
+        if not value:
+            value = 0
+            
         if isinstance(value, basestring):
             value = 0
 


### PR DESCRIPTION
We are using CouchDB 1.6.1 and /_stats returns json with null values, when value wasn't yet initialized. For example when you start couchdb and don't have opened any db yet, stats for opened database returns null. 