### PR TITLE
Add RethinkDB as an agent

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ NewRelic platform. Currently supported backend systems are:
 - PostgreSQL
 - RabbitMQ
 - Redis
+- RethinkDB
 - Riak
 - uWSGI
 
@@ -246,6 +247,14 @@ For Redis daemons that are password protected, add the password configuration va
 
 The Redis plugin can communicate either over UNIX domain sockets using the path configuration variable or TCP/IP using the host and port variables. Do not include both.
 
+RethinkDB Installation Notes
+------------------------
+You need to install the rethinkdb driver, either by running ``pip install rethinkdb``. The RethinkDB configuration section allows for multiple rethinkdb servers. The syntax to poll multiple servers is in the example below.
+
+For non-authenticated polling, leave out the auth_key variable.
+
+The RethinkDB plugin communicates TCP/IP using the host and port variables.
+
 Riak Installation Notes
 -----------------------
 If you are monitoring Riak via a HTTPS connection you can use the ``verify_ssl_cert`` configuration value in the httpd configuration section to disable SSL certificate verification.
@@ -254,7 +263,7 @@ UWSGI Installation Notes
 ------------------------
 The UWSGI plugin can communicate either over UNIX domain sockets using the path configuration variable or TCP/IP using the host and port variables. Do not include both.
 
-Make sure you have `enabled stats server 
+Make sure you have `enabled stats server
 <http://uwsgi-docs.readthedocs.org/en/latest/StatsServer.html>`_ in your uwsgi config.
 
 Configuration Example
@@ -400,6 +409,16 @@ Configuration Example
           db_count: 16
           password: foobar
           #path: /var/run/redis/redis.sock
+
+      rethinkdb:
+        - name: localhost
+          host: 127.0.0.1
+          port: 28015
+          auth_key: foobar
+        - name: localhost_2
+          host: 127.0.0.2
+          port: 28015
+          auth_key: foobar
 
       riak:
         - name: localhost

--- a/docker/base/newrelic-plugin-agent.cfg
+++ b/docker/base/newrelic-plugin-agent.cfg
@@ -139,6 +139,16 @@ Application:
   #    password: foo # [OPTIONAL]
   #    #path: /var/run/redis/redis.sock
 
+  #rethinkdb:
+  #  - name: localhost
+  #    host: 127.0.0.1
+  #    port: 28015
+  #    auth_key: foobar
+  #  - name: localhost_2
+  #    host: 127.0.0.2
+  #    port: 28015
+  #    auth_key: foobar
+
   #riak:
   #  name: localhost
   #  host: node0.riak0.scs.mtmeprod.net

--- a/etc/newrelic/newrelic-plugin-agent.cfg
+++ b/etc/newrelic/newrelic-plugin-agent.cfg
@@ -139,6 +139,16 @@ Application:
   #    password: foo # [OPTIONAL]
   #    #path: /var/run/redis/redis.sock
 
+  #rethinkdb:
+  #  - name: localhost
+  #    host: 127.0.0.1
+  #    port: 28015
+  #    auth_key: foobar
+  #  - name: localhost_2
+  #    host: 127.0.0.2
+  #    port: 28015
+  #    auth_key: foobar
+
   #riak:
   #  name: localhost
   #  host: node0.riak0.scs.mtmeprod.net

--- a/newrelic_plugin_agent/plugins/__init__.py
+++ b/newrelic_plugin_agent/plugins/__init__.py
@@ -19,5 +19,6 @@ available = {
     'postgresql': 'newrelic_plugin_agent.plugins.postgresql.PostgreSQL',
     'rabbitmq': 'newrelic_plugin_agent.plugins.rabbitmq.RabbitMQ',
     'redis': 'newrelic_plugin_agent.plugins.redis.Redis',
+    'rethinkdb': 'newrelic_plugin_agent.plugins.rethinkdb.RethinkDB',
     'riak': 'newrelic_plugin_agent.plugins.riak.Riak',
     'uwsgi': 'newrelic_plugin_agent.plugins.uwsgi.uWSGI'}

--- a/newrelic_plugin_agent/plugins/rethinkdb.py
+++ b/newrelic_plugin_agent/plugins/rethinkdb.py
@@ -1,0 +1,152 @@
+"""
+RethinkDB plugin polls RethinkDB for stats
+
+"""
+import datetime
+import rethinkdb as r
+import logging
+
+from newrelic_plugin_agent.plugins import base
+
+LOGGER = logging.getLogger(__name__)
+
+
+class RethinkDB(base.Plugin):
+
+    GUID = 'com.meetme.newrelic_rethinkdb_plugin_agent'
+
+    def add_cluster_datapoints(self, stats):
+        """Add all of the data points for a cluster
+
+        :param dict stats: The stats data to add
+
+        """
+        query_engine = stats.get('query_engine', dict())
+        self.add_gauge_value('Connections/Active', 'connections',
+                             query_engine.get('clients_active', 0))
+        self.add_gauge_value('Connections/Current', 'connections',
+                             query_engine.get('client_connections', 0))
+
+        self.add_gauge_value('Operations/Insert', 'ops',
+                             query_engine.get('written_docs_per_sec', 0))
+        self.add_gauge_value('Operations/Query', 'ops',
+                             query_engine.get('queries_per_sec', 0))
+        self.add_gauge_value('Operations/Read', 'ops',
+                             query_engine.get('read_docs_per_sec', 0))
+
+    def add_member_datapoints(self, stats):
+        """Add all of the data points for a member
+
+        :param dict stats: The stats data to add
+
+        """
+        query_engine = stats.get('query_engine', dict())
+        self.add_gauge_value('Member/Connections/Active', 'connections',
+                             query_engine.get('clients_active', 0))
+        self.add_gauge_value('Member/Connections/Current', 'connections',
+                             query_engine.get('client_connections', 0))
+
+        self.add_gauge_value('Member/Operations/Insert', 'ops',
+                             query_engine.get('written_docs_per_sec', 0))
+        self.add_gauge_value('Member/Operations/Query', 'ops',
+                             query_engine.get('queries_per_sec', 0))
+        self.add_gauge_value('Member/Operations/Read', 'ops',
+                             query_engine.get('read_docs_per_sec', 0))
+
+        self.add_derive_value('Member/Operations/Inserts Processed', 'ops',
+                              query_engine.get('written_docs_total', 0))
+        self.add_derive_value('Member/Operations/Queries Processed', 'ops',
+                              query_engine.get('queries_total', 0))
+        self.add_derive_value('Member/Operations/Reads Processed', 'ops',
+                              query_engine.get('read_docs_total', 0))
+
+    def add_database_stats(self, member_id):
+        """Add all of the data points for each table for each database
+
+        :param string member_id: The member in the cluster to get stats from
+
+        """
+        tables = list(r.db('rethinkdb').table('table_status').run())
+        for table in tables:
+            stats = r.db('rethinkdb').table('stats').get(["table_server", table['id'], member_id]).run()
+            ns = 'Database/%s/Table/%s' % (stats['db'], stats['table'])
+            query_engine = stats.get('query_engine', dict())
+            self.add_gauge_value('%s/Operations/Insert' % ns, 'ops',
+                                 query_engine.get('written_docs_per_sec', 0))
+            self.add_gauge_value('%s/Operations/Read' % ns, 'ops',
+                                 query_engine.get('read_docs_per_sec', 0))
+
+            self.add_derive_value('%s/Operations/Inserts Processed' % ns, 'ops',
+                                  query_engine.get('written_docs_total', 0))
+            self.add_derive_value('%s/Operations/Reads Processed' % ns, 'ops',
+                                  query_engine.get('read_docs_total', 0))
+
+            storage_engine = stats.get('storage_engine', dict())
+
+            cache = storage_engine.get('cache', 0)
+            self.add_gauge_value('%s/Storage/Cache' % ns, 'bytes',
+                                 cache.get('in_use_bytes', 0))
+
+            disk = storage_engine.get('disk', 0)
+            self.add_gauge_value('%s/Storage/Disk/Write' % ns, 'bytes',
+                                 disk.get('written_bytes_per_sec', 0))
+            self.add_gauge_value('%s/Storage/Disk/Read' % ns, 'bytes',
+                                 disk.get('read_bytes_per_sec', 0))
+            self.add_derive_value('%s/Storage/Disk/Writes Processed' % ns, 'bytes',
+                                  disk.get('written_bytes_total', 0))
+            self.add_derive_value('%s/Storage/Disk/Reads Processed' % ns, 'bytes',
+                                  disk.get('read_bytes_total', 0))
+
+            space_usage = disk.get('space_usage', 0)
+            self.add_gauge_value('%s/Storage/Space/Data' % ns, 'bytes',
+                                 space_usage.get('data_bytes', 0))
+            self.add_gauge_value('%s/Storage/Space/Garbage' % ns, 'bytes',
+                                 space_usage.get('garbage_bytes', 0))
+            self.add_gauge_value('%s/Storage/Space/Metadata' % ns, 'bytes',
+                                 space_usage.get('metadata_bytes', 0))
+            self.add_gauge_value('%s/Storage/Space/Preallocated' % ns, 'bytes',
+                                 space_usage.get('preallocated_bytes', 0))
+
+
+    def connect(self):
+        auth_key = self.config.get('auth_key', '')
+        try:
+            if len(auth_key):
+                r.connect(host = self.config.get('host', 'localhost'),
+                    port = self.config.get('port', 28015),
+                    db = 'rethinkdb').repl()
+            else:
+                r.connect(host = self.config.get('host', 'localhost'),
+                    port = self.config.get('port', 28015),
+                    db = 'rethinkdb',
+                    auth_key = auth_key).repl()
+        except RqlDriverError as error:
+            LOGGER.error('Could not connect to RethinkDB: %s', error)
+
+    def get_and_add_server_stats(self):
+        LOGGER.debug('Fetching server stats')
+        self.add_cluster_datapoints(r.db("rethinkdb").table("stats").get(["cluster"]).run())
+
+    def get_and_add_member_stats(self):
+        member_id = self.determine_member_id()
+        self.add_member_datapoints(r.db('rethinkdb').table('stats').get(["server", member_id]).run())
+
+    def get_and_add_db_stats(self):
+        member_id = self.determine_member_id()
+        self.addd_database_stats(member_id)
+
+    def determine_member_id(self):
+        server_status = list(r.db("rethinkdb").table("server_status").run())
+        for status in server_status:
+            for member in list(status['network']['canonical_addresses']):
+                if member['host'] == self.config.get('host', 'localhost'):
+                    return status['id']
+
+    def poll(self):
+        self.initialize()
+        self.connect()
+        self.get_and_add_server_stats()
+        self.get_and_add_member_stats()
+        self.get_and_add_db_stats()
+        self.close()
+        self.finish()


### PR DESCRIPTION
With the introduction of RethinkDB 1.16.X, the ability to retrieve stats from the system is greatly improved within the API. I'd like to be able to monitor RethinkDB clusters using the New Relic plugin agent.

I know there is some additional work to build the UI layout but would be happy to assist with that process as well.
