### PR TITLE
Allow custom http host headers for HTTP stats fetches

### DIFF
--- a/newrelic_plugin_agent/plugins/base.py
+++ b/newrelic_plugin_agent/plugins/base.py
@@ -403,6 +403,9 @@ class HTTPStatsPlugin(Plugin):
         if 'username' in self.config and 'password' in self.config:
             kwargs['auth'] = (self.config['username'], self.config['password'])
 
+        if 'httphost' in self.config:
+            kwargs['headers'] = {'Host': self.config['httphost']}
+
         LOGGER.debug('Request kwargs: %r', kwargs)
         return kwargs
 


### PR DESCRIPTION
It's common to have multiple FPM pools etc each serving one domain name / set of domains under a webserver. As such, it's often necessary to monitor these individually. In some cases the public hostnames won't help (for instance, if the public hostname points to a load balancer) so it's necessary to connect to localhost however serve a different HTTP hostname.