### PR TITLE
Fix #418, Windows Redis yields ValueError

### DIFF
--- a/newrelic_plugin_agent/plugins/redis.py
+++ b/newrelic_plugin_agent/plugins/redis.py
@@ -145,7 +145,7 @@ class Redis(base.SocketStatsPlugin):
         values = dict()
         for line in lines:
             if ':' in line:
-                key, value = line.strip().split(':')
+                key, value = line.strip().split(':',1)
                 if key[:2] == 'db':
                     values[key] = dict()
                     subvalues = value.split(',')


### PR DESCRIPTION
This defensive programming fix gets around a fatal ValueError when connecting to Windows Redis instances, see https://github.com/MeetMe/newrelic-plugin-agent/issues/418