### PR TITLE
Explicitly type-cast pg_lsn to text (postgresql plugin)

### DIFF
--- a/newrelic_plugin_agent/plugins/postgresql.py
+++ b/newrelic_plugin_agent/plugins/postgresql.py
@@ -58,10 +58,10 @@ SELECT
 FROM (
     SELECT
         client_addr, client_hostname, state,
-        ('x' || lpad(split_part(sent_location,   '/', 1), 8, '0'))::bit(32)::bigint AS sent_xlog,
-        ('x' || lpad(split_part(replay_location, '/', 1), 8, '0'))::bit(32)::bigint AS replay_xlog,
-        ('x' || lpad(split_part(sent_location,   '/', 2), 8, '0'))::bit(32)::bigint AS sent_offset,
-        ('x' || lpad(split_part(replay_location, '/', 2), 8, '0'))::bit(32)::bigint AS replay_offset
+        ('x' || lpad(split_part(sent_location::text,   '/', 1), 8, '0'))::bit(32)::bigint AS sent_xlog,
+        ('x' || lpad(split_part(replay_location::text, '/', 1), 8, '0'))::bit(32)::bigint AS replay_xlog,
+        ('x' || lpad(split_part(sent_location::text,   '/', 2), 8, '0'))::bit(32)::bigint AS sent_offset,
+        ('x' || lpad(split_part(replay_location::text, '/', 2), 8, '0'))::bit(32)::bigint AS replay_offset
     FROM pg_stat_replication
 ) AS s;
 """


### PR DESCRIPTION
This fixes the following error on postgresql-9.4:

```
ERROR:  function split_part(pg_lsn, unknown, integer) does not exist
LINE 3:         ('x' || lpad(split_part(sent_location,   '/', 1), 8,...
                             ^
HINT:  No function matches the given name and argument types. You might need to add explicit type
casts.
```

The patch introducing this error: https://github.com/MeetMe/newrelic-plugin-agent/pull/285
