### PR TITLE
Keep uwsgi plugin from crashing the agent

### DIFF
--- a/newrelic_plugin_agent/plugins/uwsgi.py
+++ b/newrelic_plugin_agent/plugins/uwsgi.py
@@ -96,6 +96,9 @@ class uWSGI(base.SocketStatsPlugin):
         data = super(uWSGI, self).fetch_data(connection, read_till_empty=True)
         if data:
             data = re.sub(r'"HTTP_COOKIE=[^"]*"', '""', data)
-            return json.loads(data)
+            try:
+                return json.loads(data)
+            except ValueError as ve:
+                LOGGER.error("Failed to parse received JSON object: %s" % ve)
+                return {}
         return {}
-


### PR DESCRIPTION
Uwsgi plugin sometimes receives truncated data back from the uwsgi
stats server. When this happens, json.loads() fails to process the
data, and throws an exception. This bubbled up all the way to the
main python process and halted the agent.

IMO, this should not be an agent-killing problem. Wrapping json.loads()
with a try-except block and giving it some default behavior keeps it
from exploding when it recieves bad data.