### PR TITLE
Support a URL scheme without port

### DIFF
--- a/newrelic_plugin_agent/plugins/rabbitmq.py
+++ b/newrelic_plugin_agent/plugins/rabbitmq.py
@@ -386,5 +386,9 @@ class RabbitMQ(base.Plugin):
         api_path = self.config.get('api_path', self.DEFAULT_API_PATH)
         scheme = 'https' if secure else 'http'
 
-        return '{scheme}://{host}:{port}{api_path}'.format(
+        url = '{scheme}://{host}:{port}{api_path}'
+        if port == 'none':
+            url = '{scheme}://{host}{api_path}'
+
+        return url.format(
             scheme=scheme, host=host, port=port, api_path=api_path)


### PR DESCRIPTION
In some cases, such as connecting the plugin to a cloud-hosted RabbitMQ at
lshift.net, the API URL should be constructed without the port in order for
connection to be successful.

Before the fix, the URLs looks like this:
`http://bigwig.lshift.net/management/12345:80/api/channels`

After the fix, like this:
`http://bigwig.lshift.net/management/12345/api/channels`

Notice the `:80` that is added in the path part of the URL. To skip adding
the port number to the URL, the user should add the following to the config:
`port: none`.
