### PR TITLE
Support delegated auth for mongo plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,9 +193,13 @@ If your MongoDB server requires authentication, you must provide both admin cred
             password: bar
 
 
-If you would like to use delegated authentication you need to add auth_db to desired databases. Example below shows unlikely case of three different authentication scenarios:
-database_name_1 uses admin db with admin_username and admin_password to authenticate.
-database_name_2 uses foobar_db and database_name_3 uses its local username and password.
+If you would like to use delegated authentication you need to add ``auth_db`` to desired databases.
+
+Example below shows unlikely case of three different authentication scenarios:
+
+- database_name_1 uses credentials defined in admin database (admin_username and admin_password).
+- database_name_2 uses credentials defined in foobar database
+- database_name_3 uses locally defined credentials.
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ There are two configuration stanza formats for MongoDB. You must use one or the 
           - database_name_1
           - database_name_2
 
-If your MongoDB server requires authentication, you must provide both admin credentials and database level credentials and the stanza is formatted as a nested array:
+If your MongoDB server requires authentication, you must provide both admin credentials and database level credentials (or use delegated authentication as explained later) and the stanza is formatted as a nested array:
 
 ::
 
@@ -191,6 +191,35 @@ If your MongoDB server requires authentication, you must provide both admin cred
           database_name_2:
             username: foo
             password: bar
+
+
+If you would like to use delegated authentication you need to add auth_db to desired databases. Example below shows unlikely case of three different authentication scenarios:
+database_name_1 uses admin db with admin_username and admin_password to authenticate.
+database_name_2 uses foobar_db and database_name_3 uses its local username and password.
+
+::
+
+      mongodb:
+        name: hostname
+        host: localhost
+        port: 27017
+        #admin_username: foo
+        #admin_password: bar
+        #ssl: False
+        #ssl_keyfile: /path/to/keyfile
+        #ssl_certfile: /path/to/certfile
+        #ssl_cert_reqs: 0  # Should be 0 for ssl.CERT_NONE, 1 for ssl.CERT_OPTIONAL, 2 for ssl.CERT_REQUIRED
+        #ssl_ca_certs: /path/to/cacerts file
+        databases:
+          database_name_1:
+            auth_db:  admin
+          database_name_2:
+            auth_db: foobar_db
+            username: foo_2
+            password: bar_2
+          database_name_3:
+            username: foo_3
+            password: bar_3
 
 Nginx Installation Notes
 ------------------------

--- a/newrelic_plugin_agent/plugins/mongodb.py
+++ b/newrelic_plugin_agent/plugins/mongodb.py
@@ -231,7 +231,17 @@ class MongoDB(base.Plugin):
         for database in db_names:
             db = client[database]
             try:
-                if 'username' in databases[database]:
+                if 'delegated_auth' in databases[database]:
+                    auth_db = databases[database].get('delegated_auth')
+                    if auth_db == 'admin':
+                        db.authenticate(self.config['admin_username'],
+                                      self.config.get('admin_password'),
+                                                         source=auth_db)
+                    else:
+                        db.authenticate(databases[database]['username'],
+                                      databases[database].get('password'),
+                                                           source=auth_db)
+                elif 'username' in databases[database]:
                     db.authenticate(databases[database]['username'],
                                     databases[database].get('password'))
                 self.add_datapoints(database, db.command('dbStats'))

--- a/newrelic_plugin_agent/plugins/mongodb.py
+++ b/newrelic_plugin_agent/plugins/mongodb.py
@@ -231,8 +231,8 @@ class MongoDB(base.Plugin):
         for database in db_names:
             db = client[database]
             try:
-                if 'delegated_auth' in databases[database]:
-                    auth_db = databases[database].get('delegated_auth')
+                if 'auth_db' in databases[database]:
+                    auth_db = databases[database].get('auth_db')
                     if auth_db == 'admin':
                         db.authenticate(self.config['admin_username'],
                                       self.config.get('admin_password'),


### PR DESCRIPTION
It is useful to me to monitor all databases using one user.
With delegated authentication it's easily achievable.
