### PR TITLE
Enabling env var support for license key and app names

### DIFF
--- a/newrelic_plugin_agent/agent.py
+++ b/newrelic_plugin_agent/agent.py
@@ -85,7 +85,10 @@ class NewRelicPluginAgent(helper.Controller):
         :rtype: str
 
         """
-        return self.config.application.license_key
+        licenseKey = os.getenv('NEWRELIC_LICENSE_KEY')
+        if licenseKey == None:
+            licenseKey = self.config.application.license_key
+        return licenseKey
 
     def poll_plugin(self, plugin_name, plugin, config):
         """Kick off a background thread to run the processing task.
@@ -98,7 +101,10 @@ class NewRelicPluginAgent(helper.Controller):
         if not isinstance(config, (list, tuple)):
             config = [config]
 
-        for instance in config:
+        for idx, instance in enumerate(config):
+            appName = os.getenv("NEWRELIC_%s_APP_NAME_%i" % (plugin_name.upper(), idx))
+            if appName != None:
+                instance.name = appName
             thread = threading.Thread(target=self.thread_process,
                                       kwargs={'config': instance,
                                               'name': plugin_name,


### PR DESCRIPTION
- This will allow the overriding of both the license key and **all** the app names, through env vars
- For the license key, we just have to define `NEWRELIC_LICENSE_KEY`
- For an app name, it's more tricky, since we want to support multiple instances per supported backend system. The format is `NEWRELIC_<UPPERCASE_PLUGIN_NAME>_<INSTANCE_INDEX>` (e.g. if we want to override the first `apache_httpd` app name, we would define `NEWRELIC_APACHE_HTTPD_APP_NAME_0`)
