### PR TITLE
Postfix plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -407,6 +407,8 @@ Configuration Example
           port: 8098
           #verify_ssl_cert: true
 
+      postfix: {}
+
     Daemon:
       user: newrelic
       pidfile: /var/run/newrelic/newrelic-plugin-agent.pid

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ NewRelic platform. Currently supported backend systems are:
 - Redis
 - Riak
 - uWSGI
+- Postfix
 
 Base Requirements
 -----------------
@@ -256,6 +257,11 @@ The UWSGI plugin can communicate either over UNIX domain sockets using the path 
 
 Make sure you have `enabled stats server 
 <http://uwsgi-docs.readthedocs.org/en/latest/StatsServer.html>`_ in your uwsgi config.
+
+Postfix Installation Notes
+------------------------
+
+The Postfix plugin needs root permissions to find and read the Postfix queue directory to monitor queue sizes, so you must install the newrelic-plugin-agent as root to use the Postfix plugin
 
 Configuration Example
 ---------------------

--- a/newrelic_plugin_agent/plugins/__init__.py
+++ b/newrelic_plugin_agent/plugins/__init__.py
@@ -20,4 +20,5 @@ available = {
     'rabbitmq': 'newrelic_plugin_agent.plugins.rabbitmq.RabbitMQ',
     'redis': 'newrelic_plugin_agent.plugins.redis.Redis',
     'riak': 'newrelic_plugin_agent.plugins.riak.Riak',
+    'postfix': 'newrelic_plugin_agent.plugins.postfix.Postfix',
     'uwsgi': 'newrelic_plugin_agent.plugins.uwsgi.uWSGI'}

--- a/newrelic_plugin_agent/plugins/postfix.py
+++ b/newrelic_plugin_agent/plugins/postfix.py
@@ -17,12 +17,12 @@ class Postfix(base.Plugin):
 
     def poll(self):
         try:
-            self.add_gauge_value("Postfix/DeferredQueueSize", None, self.queue_size("deferred")) 
-            self.add_gauge_value("Postfix/BounceQueueSize", None, self.queue_size("bounce")) 
-            self.add_gauge_value("Postfix/HoldQueueSize", None, self.queue_size("hold"))
-            self.add_gauge_value("Postfix/CorruptQueueSize", None, self.queue_size("corrupt"))
-            self.add_gauge_value("Postfix/IncomingQueueSize", None, self.queue_size("incoming"))
-            self.add_gauge_value("Postfix/ActiveQueueSize", None, self.queue_size("active")) 
+            self.add_gauge_value("Postfix/DeferredQueueSize", "messages", self.queue_size("deferred")) 
+            self.add_gauge_value("Postfix/BounceQueueSize", "messages", self.queue_size("bounce")) 
+            self.add_gauge_value("Postfix/HoldQueueSize", "messages", self.queue_size("hold"))
+            self.add_gauge_value("Postfix/CorruptQueueSize", "messages", self.queue_size("corrupt"))
+            self.add_gauge_value("Postfix/IncomingQueueSize", "messages", self.queue_size("incoming"))
+            self.add_gauge_value("Postfix/ActiveQueueSize", "messages", self.queue_size("active")) 
 
             self.finish()
         except ShellCommandFailed as e:

--- a/newrelic_plugin_agent/plugins/postfix.py
+++ b/newrelic_plugin_agent/plugins/postfix.py
@@ -4,24 +4,32 @@ Postfix
 """
 from newrelic_plugin_agent.plugins import base
 import subprocess
+import logging
 
+LOGGER = logging.getLogger(__name__)
+
+class ShellCommandFailed(Exception):
+    """ Raised when a shell command fails """
 
 class Postfix(base.Plugin):
 
     GUID = 'com.supportbee.newrelic_postfix_agent'
 
     def poll(self):
-        self.add_gauge_value("Postfix/DeferredQueueSize", None, self.queue_size("deferred")) 
-        self.add_gauge_value("Postfix/BounceQueueSize", None, self.queue_size("bounce")) 
-        self.add_gauge_value("Postfix/HoldQueueSize", None, self.queue_size("hold"))
-        self.add_gauge_value("Postfix/CorruptQueueSize", None, self.queue_size("corrupt"))
-        self.add_gauge_value("Postfix/IncomingQueueSize", None, self.queue_size("incoming"))
-        self.add_gauge_value("Postfix/ActiveQueueSize", None, self.queue_size("active")) 
+        try:
+            self.add_gauge_value("Postfix/DeferredQueueSize", None, self.queue_size("deferred")) 
+            self.add_gauge_value("Postfix/BounceQueueSize", None, self.queue_size("bounce")) 
+            self.add_gauge_value("Postfix/HoldQueueSize", None, self.queue_size("hold"))
+            self.add_gauge_value("Postfix/CorruptQueueSize", None, self.queue_size("corrupt"))
+            self.add_gauge_value("Postfix/IncomingQueueSize", None, self.queue_size("incoming"))
+            self.add_gauge_value("Postfix/ActiveQueueSize", None, self.queue_size("active")) 
 
-        self.finish()
+            self.finish()
+        except ShellCommandFailed as e:
+            LOGGER.error(str(e))
 
     def queue_size(self, queue):
-        command = "find " + self.postfix_queue_directory() + "/" + queue + " type -f | wc -l"
+        command = "find " + self.postfix_queue_directory() + "/" + queue + " -type f | wc -l"
         queue_size = int(self.run_shell_command(command))
         return queue_size
 
@@ -33,4 +41,8 @@ class Postfix(base.Plugin):
     def run_shell_command(self, command):
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, shell=True)
         stdout_data, stderr_data = process.communicate()
+        if stderr_data:
+            error_message = "Running shell command `{0}` failed with error: `{1}`".format(command, stderr_data.rstrip())
+            raise ShellCommandFailed(error_message)
+
         return stdout_data.rstrip()

--- a/newrelic_plugin_agent/plugins/postfix.py
+++ b/newrelic_plugin_agent/plugins/postfix.py
@@ -1,0 +1,36 @@
+"""
+Postfix
+
+"""
+from newrelic_plugin_agent.plugins import base
+import subprocess
+
+
+class Postfix(base.Plugin):
+
+    GUID = 'com.supportbee.newrelic_postfix_agent'
+
+    def poll(self):
+        self.add_gauge_value("Postfix/DeferredQueueSize", None, self.queue_size("deferred")) 
+        self.add_gauge_value("Postfix/BounceQueueSize", None, self.queue_size("bounce")) 
+        self.add_gauge_value("Postfix/HoldQueueSize", None, self.queue_size("hold"))
+        self.add_gauge_value("Postfix/CorruptQueueSize", None, self.queue_size("corrupt"))
+        self.add_gauge_value("Postfix/IncomingQueueSize", None, self.queue_size("incoming"))
+        self.add_gauge_value("Postfix/ActiveQueueSize", None, self.queue_size("active")) 
+
+        self.finish()
+
+    def queue_size(self, queue):
+        command = "find " + self.postfix_queue_directory() + "/" + queue + " type -f | wc -l"
+        queue_size = int(self.run_shell_command(command))
+        return queue_size
+
+    def postfix_queue_directory(self):
+        if not getattr(self, '_postfix_queue_directory', None):
+            self._postfix_queue_directory = self.run_shell_command("postconf -h queue_directory")
+        return self._postfix_queue_directory
+
+    def run_shell_command(self, command):
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, shell=True)
+        stdout_data, stderr_data = process.communicate()
+        return stdout_data.rstrip()


### PR DESCRIPTION
This PR adds a plugin for [Postfix](http://www.postfix.org/).

The plugin
- Monitors the Deferred, Bounced, Hold, Corrupt, Incoming and Active queues of a Postfix instance running on the same server as the plugin
- Alerts Plugin Users (who haven't migrated to the [New Relic Alerts](https://newrelic.com/alerts) product yet) if the Deferred or the Bounced queues have too many (> 100) messages for more than 5 minutes. Plugin Users who've migrated to the [New Relic Alerts] product can easily setup the same alerts by visiting https://alerts.newrelic.com/

I've been testing the plugin on our staging server since two days and it works well

![screen shot 2016-10-26 at 9 04 22 pm](https://cloud.githubusercontent.com/assets/1789832/19733061/7d34cb7a-9bc0-11e6-93ff-85fcfa89a93f.png)

I'm currently deploying this plugin to all our production servers. I'll be publising the plugin in New Relic's Plugin Central once this PR gets reviewed and merged. Thanks!
