### PR TITLE
fix: lock helper version to 2.4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ data_files[base_path] = ['LICENSE',
                          'apc-nrp.php']
 
 console_scripts = ['newrelic-plugin-agent=newrelic_plugin_agent.agent:main']
-install_requires = ['helper>=2.2.2', 'requests>=2.0.0']
+install_requires = ['helper==2.4.2', 'requests>=2.0.0']
 tests_require = []
 extras_require = {'mongodb': ['pymongo'],
                   'pgbouncer': ['psycopg2'],


### PR DESCRIPTION
Lock version of helper to 2.4.2 to address the problem  with the recent release of `helper` library: #564.